### PR TITLE
Add a small ratelimit to screen toggle

### DIFF
--- a/lua/autorun/client/cl_chip_lister.lua
+++ b/lua/autorun/client/cl_chip_lister.lua
@@ -4,6 +4,7 @@ local TOGGLE_DIST = 1500
 local MAX_ELEMENTS = 30
 local SCREEN_SIZE = 1024
 local SCREEN_SIZE_HALF = SCREEN_SIZE / 2
+local USE_COOLDOWN = 0.5
 
 local FONT_NAME = "CFC_ChipLister_Font"
 local FONT_SIZE = 30
@@ -31,6 +32,7 @@ local ID_WORLD = "[WORLD]"
 local CPUS_FORMAT = "%05d"
 
 
+local useIsOnCooldown = false
 local rtChipLister = GetRenderTarget( "cfc_chiplister_rt", SCREEN_SIZE, SCREEN_SIZE )
 local INFO_OFFSET_OWNER = 0
 local INFO_OFFSET_CHIP = 0
@@ -309,6 +311,7 @@ end )
 
 hook.Add( "KeyPress", "CFC_ChipLister_ToggleScreen", function( ply, key ) -- ply is always LocalPlayer() on client
     if key ~= IN_USE then return end
+    if useIsOnCooldown then return end
 
     local tr = ply:GetEyeTrace()
     local ent = tr.Entity
@@ -317,6 +320,12 @@ hook.Add( "KeyPress", "CFC_ChipLister_ToggleScreen", function( ply, key ) -- ply
     if tr.StartPos:DistToSqr( tr.HitPos ) > TOGGLE_DIST_SQR then return end
 
     ply:ConCommand( "cfc_chiplister_enabled " .. ( listerEnabled and "0" or "1" ) )
+
+    useIsOnCooldown = true
+
+    timer.simple( USE_COOLDOWN, function()
+        useIsOnCooldown = false
+    end )
 end )
 
 

--- a/lua/autorun/client/cl_chip_lister.lua
+++ b/lua/autorun/client/cl_chip_lister.lua
@@ -32,7 +32,6 @@ local ID_WORLD = "[WORLD]"
 local CPUS_FORMAT = "%05d"
 
 
-local useIsOnCooldown = false
 local rtChipLister = GetRenderTarget( "cfc_chiplister_rt", SCREEN_SIZE, SCREEN_SIZE )
 local INFO_OFFSET_OWNER = 0
 local INFO_OFFSET_CHIP = 0
@@ -311,7 +310,7 @@ end )
 
 hook.Add( "KeyPress", "CFC_ChipLister_ToggleScreen", function( ply, key ) -- ply is always LocalPlayer() on client
     if key ~= IN_USE then return end
-    if useIsOnCooldown then return end
+    if not IsFirstTimePredicted() then return end
 
     local tr = ply:GetEyeTrace()
     local ent = tr.Entity
@@ -320,12 +319,6 @@ hook.Add( "KeyPress", "CFC_ChipLister_ToggleScreen", function( ply, key ) -- ply
     if tr.StartPos:DistToSqr( tr.HitPos ) > TOGGLE_DIST_SQR then return end
 
     ply:ConCommand( "cfc_chiplister_enabled " .. ( listerEnabled and "0" or "1" ) )
-
-    useIsOnCooldown = true
-
-    timer.Simple( USE_COOLDOWN, function()
-        useIsOnCooldown = false
-    end )
 end )
 
 

--- a/lua/autorun/client/cl_chip_lister.lua
+++ b/lua/autorun/client/cl_chip_lister.lua
@@ -323,7 +323,7 @@ hook.Add( "KeyPress", "CFC_ChipLister_ToggleScreen", function( ply, key ) -- ply
 
     useIsOnCooldown = true
 
-    timer.simple( USE_COOLDOWN, function()
+    timer.Simple( USE_COOLDOWN, function()
         useIsOnCooldown = false
     end )
 end )

--- a/lua/autorun/client/cl_chip_lister.lua
+++ b/lua/autorun/client/cl_chip_lister.lua
@@ -4,7 +4,6 @@ local TOGGLE_DIST = 1500
 local MAX_ELEMENTS = 30
 local SCREEN_SIZE = 1024
 local SCREEN_SIZE_HALF = SCREEN_SIZE / 2
-local USE_COOLDOWN = 0.5
 
 local FONT_NAME = "CFC_ChipLister_Font"
 local FONT_SIZE = 30


### PR DESCRIPTION
Prevent issues where someone's use key might press twice rapidly, causing them to not be able to toggle the listers correctly.