### PR TITLE
Still check for players using the HUD even if no lister ents are spawned

### DIFF
--- a/lua/autorun/server/sv_chip_lister.lua
+++ b/lua/autorun/server/sv_chip_lister.lua
@@ -119,7 +119,7 @@ end
 local function canSeeALister( ply, listers )
     if not IsValid( ply ) then return false end
     if ply:GetInfoNum( "cfc_chiplister_hud_persist", 0 ) == 1 then return true end
-    if not listers then return end
+    if not listers then return false end
 
     local aimEnt = ply:GetEyeTrace().Entity
     if IsValid( aimEnt ) and aimEnt:GetClass() == "cfc_chip_lister" then return true end

--- a/lua/autorun/server/sv_chip_lister.lua
+++ b/lua/autorun/server/sv_chip_lister.lua
@@ -115,9 +115,11 @@ local function isPlateVisible( ent, ply )
 end
 
 -- Can a player see at least one chip lister?
+-- Give listers as false to only check for the HUD setting (i.e. no lister entities exist).
 local function canSeeALister( ply, listers )
     if not IsValid( ply ) then return false end
     if ply:GetInfoNum( "cfc_chiplister_hud_persist", 0 ) == 1 then return true end
+    if not listers then return end
 
     local aimEnt = ply:GetEyeTrace().Entity
     if IsValid( aimEnt ) and aimEnt:GetClass() == "cfc_chip_lister" then return true end
@@ -134,7 +136,10 @@ local function getVisibleListUsers()
     if listUserCount == 0 then return {}, 0 end
 
     local listers = ents.FindByClass( "cfc_chip_lister" )
-    if #listers == 0 then return {}, 0 end
+
+    if #listers == 0 then
+        listers = false
+    end
 
     local visibleUsers = {}
     local visibleUserCount = 0


### PR DESCRIPTION
Fixes [this unreported issue](https://github.com/edshot99/cfc_chip_lister/commit/28f4a2455520dfcdede22e8d9cb586ca83753ad3)