### PR TITLE
HUD QoL and Babyproofing

### DIFF
--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -73,6 +73,7 @@ CreateMaterial( "cfc_chiplister_screen", "UnlitGeneric", {
 
 concommand.Add( "cfc_chiplister_open_hud", openListerPanel, nil, "Opens the Chip Lister as a HUD element." )
 concommand.Add( "cfc_chiplister_close_hud", closeListerPanel, nil, "Closes the Chip Lister HUD element." )
+concommand.Add( "cfc_chiplister_toggle_hud", toggleListerPanel, nil, "Toggles the Chip Lister HUD element." )
 net.Receive( "CFC_ChipLister_ToggleHUD", toggleListerPanel )
 
 
@@ -83,7 +84,7 @@ end )
 hook.Add( "PopulateToolMenu", "CFC_ChipLister_PopulateToolMenu", function()
     spawnmenu.AddToolMenuOption( "Options", "CFC", "cfc_chiplister", "#Chip Lister", "", "", function( panel )
         panel:CheckBox( "Enable E2/SF Lister", "cfc_chiplister_enabled" )
-        panel:Button( "Open Chip Lister on HUD", "cfc_chiplister_open_hud" )
+        panel:Button( "Toggle Chip Lister on HUD", "cfc_chiplister_toggle_hud" )
     end )
 end )
 

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -1,15 +1,27 @@
 local listerPanel
 local ignoringPosConvars = false
 
-local PANEL_MIN_SIZE = 200
+local PANEL_MIN_SIZE_FRAC = 200 / 1080
+local PANEL_DEFAULT_SIZE_FRAC = 400 / 1080
 
 local PANEL_PERSIST = CreateClientConVar( "cfc_chiplister_hud_persist", 0, true, true, "Causes the chiplister HUD element to persist across sessions." )
 local PANEL_POS_X = CreateClientConVar( "cfc_chiplister_hud_pos_x", 50, true, false, "X-Position of the chiplister HUD element." )
 local PANEL_POS_Y = CreateClientConVar( "cfc_chiplister_hud_pos_y", 25, true, false, "Y-Position of the chiplister HUD element." )
-local PANEL_SIZE = CreateClientConVar( "cfc_chiplister_hud_size", 275, true, false, "Size of the chiplister HUD element." )
+local PANEL_SIZE_FRAC = CreateClientConVar( "cfc_chiplister_hud_size_frac", -1, true, false, "Fractional size of the chiplister HUD element. -1 For the addon default.", -1, 1 )
 
 local LISTER_ENABLED = GetConVar( "cfc_chiplister_enabled" )
 
+
+local function clampSize( size )
+    return math.max( size, ScrH() * PANEL_MIN_SIZE_FRAC )
+end
+
+local function getSizeFromConvar()
+    local frac = PANEL_SIZE_FRAC:GetFloat()
+    if frac < 0 then frac = PANEL_DEFAULT_SIZE_FRAC end
+
+    return clampSize( frac * ScrH() )
+end
 
 local function openListerPanel()
     if IsValid( listerPanel ) then
@@ -20,7 +32,7 @@ local function openListerPanel()
     end
 
     listerPanel = vgui.Create( "DFrame" )
-    listerPanel:SetSize( PANEL_SIZE:GetInt(), PANEL_SIZE:GetInt() )
+    listerPanel:SetSize( getSizeFromConvar(), getSizeFromConvar() )
     listerPanel:SetPos( PANEL_POS_X:GetInt(), PANEL_POS_Y:GetInt() )
     listerPanel:SetSizable( true )
     listerPanel:SetScreenLock( true )
@@ -65,10 +77,10 @@ local function openListerPanel()
 
     local _SetSize = listerPanel.SetSize
     function listerPanel:SetSize( w, h )
-        local size = math.max( math.min( w, h ), PANEL_MIN_SIZE ) -- Keep it as a square
+        local size = clampSize( math.min( w, h ) ) -- Keep it as a square
 
         _SetSize( self, size, size )
-        LocalPlayer():ConCommand( "cfc_chiplister_hud_size " .. size )
+        PANEL_SIZE_FRAC:SetFloat( size / 1080 )
     end
 
     LocalPlayer():ConCommand( "cfc_chiplister_hud_persist 1" )

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -1,13 +1,15 @@
 local listerPanel
 local ignoringPosConvars = false
 
-local PANEL_MIN_SIZE_FRAC = 300 / 1080
+local PANEL_DEFAULT_POS_FRAC_X = 50 / 1920
+local PANEL_DEFAULT_POS_FRAC_Y = 25 / 1080
 local PANEL_DEFAULT_SIZE_FRAC = 400 / 1080
+local PANEL_MIN_SIZE_FRAC = 300 / 1080
 
 local PANEL_PERSIST = CreateClientConVar( "cfc_chiplister_hud_persist", 0, true, true, "Causes the chiplister HUD element to persist across sessions." )
-local PANEL_POS_X = CreateClientConVar( "cfc_chiplister_hud_pos_x", 50, true, false, "X-Position of the chiplister HUD element." )
-local PANEL_POS_Y = CreateClientConVar( "cfc_chiplister_hud_pos_y", 25, true, false, "Y-Position of the chiplister HUD element." )
-local PANEL_SIZE_FRAC = CreateClientConVar( "cfc_chiplister_hud_size_frac", -1, true, false, "Fractional size of the chiplister HUD element. -1 For the addon default.", -1, 1 )
+local PANEL_POS_FRAC_X = CreateClientConVar( "cfc_chiplister_hud_pos_frac_x", -1, true, false, "Fractional X-Position of the chiplister HUD element. -1 for the addon default.", -1, 1 )
+local PANEL_POS_FRAC_Y = CreateClientConVar( "cfc_chiplister_hud_pos_frac_y", -1, true, false, "Fractional Y-Position of the chiplister HUD element. -1 for the addon default.", -1, 1 )
+local PANEL_SIZE_FRAC = CreateClientConVar( "cfc_chiplister_hud_size_frac", -1, true, false, "Fractional size of the chiplister HUD element. -1 for the addon default.", -1, 1 )
 
 local LISTER_ENABLED = GetConVar( "cfc_chiplister_enabled" )
 
@@ -23,6 +25,18 @@ local function getSizeFromConvar()
     return clampSize( frac * ScrH() )
 end
 
+local function getPosFromConvar( fracX, fracY )
+    fracX = fracX or PANEL_POS_FRAC_X:GetFloat()
+    if fracX < 0 then fracX = PANEL_DEFAULT_POS_FRAC_X end
+    fracX = math.Clamp( fracX, 0, 1 )
+
+    fracY = fracY or PANEL_POS_FRAC_Y:GetFloat()
+    if fracY < 0 then fracY = PANEL_DEFAULT_POS_FRAC_Y end
+    fracY = math.Clamp( fracY, 0, 1 )
+
+    return fracX * ScrW(), fracY * ScrH()
+end
+
 local function openListerPanel()
     if IsValid( listerPanel ) then
         listerPanel:Show()
@@ -33,7 +47,7 @@ local function openListerPanel()
 
     listerPanel = vgui.Create( "DFrame" )
     listerPanel:SetSize( getSizeFromConvar(), getSizeFromConvar() )
-    listerPanel:SetPos( PANEL_POS_X:GetInt(), PANEL_POS_Y:GetInt() )
+    listerPanel:SetPos( getPosFromConvar() )
     listerPanel:SetSizable( true )
     listerPanel:SetScreenLock( true )
     listerPanel:SetTitle( "E2/SF Lister    (Open chat for cursor)" )
@@ -69,8 +83,8 @@ local function openListerPanel()
         if not noConvar then
             local oldState = ignoringPosConvars
             ignoringPosConvars = true
-            PANEL_POS_X:SetInt( x )
-            PANEL_POS_Y:SetInt( y )
+            PANEL_POS_FRAC_X:SetFloat( x / ScrW() )
+            PANEL_POS_FRAC_Y:SetFloat( y / ScrH() )
             ignoringPosConvars = oldState
         end
     end
@@ -100,12 +114,11 @@ local function toggleListerPanel()
     end
 end
 
-local function setPosFromConvar( x, y )
+local function setPosFromConvar( fracX, fracY )
     if ignoringPosConvars then return end
     if not IsValid( listerPanel ) then return end
 
-    x = x or PANEL_POS_X:GetInt()
-    y = y or PANEL_POS_Y:GetInt()
+    local x, y = getPosFromConvar( fracX, fracY )
     listerPanel:SetPos( x, y, true )
 end
 
@@ -121,11 +134,11 @@ concommand.Add( "cfc_chiplister_toggle_hud", toggleListerPanel, nil, "Toggles th
 net.Receive( "CFC_ChipLister_ToggleHUD", toggleListerPanel )
 
 
-cvars.AddChangeCallback( "cfc_chiplister_hud_pos_x", function( _, _, new )
+cvars.AddChangeCallback( "cfc_chiplister_hud_pos_frac_x", function( _, _, new )
     setPosFromConvar( tonumber( new ), nil )
 end, "CFC_ShipLister_MoveHUD" )
 
-cvars.AddChangeCallback( "cfc_chiplister_hud_pos_y", function( _, _, new )
+cvars.AddChangeCallback( "cfc_chiplister_hud_pos_frac_y", function( _, _, new )
     setPosFromConvar( nil, tonumber( new ) )
 end, "CFC_ShipLister_MoveHUD" )
 
@@ -142,8 +155,8 @@ hook.Add( "PopulateToolMenu", "CFC_ChipLister_PopulateToolMenu", function()
         local btnReset = panel:Button( "Reset HUD Position" )
 
         function btnReset:DoClick()
-            PANEL_POS_X:Revert()
-            PANEL_POS_Y:Revert()
+            PANEL_POS_FRAC_X:Revert()
+            PANEL_POS_FRAC_Y:Revert()
         end
     end )
 end )

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -94,7 +94,7 @@ local function openListerPanel()
         local size = clampSize( math.min( w, h ) ) -- Keep it as a square
 
         _SetSize( self, size, size )
-        PANEL_SIZE_FRAC:SetFloat( size / 1080 )
+        PANEL_SIZE_FRAC:SetFloat( size / ScrH() )
     end
 
     LocalPlayer():ConCommand( "cfc_chiplister_hud_persist 1" )

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -1,5 +1,6 @@
 local listerPanel
 local ignoringPosConvars = false
+local ignoringSizeConvar = false
 
 local PANEL_DEFAULT_POS_FRAC_X = 50 / 1920
 local PANEL_DEFAULT_POS_FRAC_Y = 25 / 1080
@@ -94,11 +95,17 @@ local function openListerPanel()
     end
 
     local _SetSize = listerPanel.SetSize
-    function listerPanel:SetSize( w, h )
+    function listerPanel:SetSize( w, h, noConvar )
         local size = clampSize( math.min( w, h ) ) -- Keep it as a square
 
         _SetSize( self, size, size )
-        PANEL_SIZE_FRAC:SetFloat( size / ScrH() )
+
+        if not noConvar then
+            local oldState = ignoringSizeConvar
+            ignoringSizeConvar = true
+            PANEL_SIZE_FRAC:SetFloat( size / ScrH() )
+            ignoringSizeConvar = oldState
+        end
     end
 
     LocalPlayer():ConCommand( "cfc_chiplister_hud_persist 1" )
@@ -146,6 +153,14 @@ cvars.AddChangeCallback( "cfc_chiplister_hud_pos_frac_y", function( _, _, new )
     setPosFromConvar( nil, tonumber( new ) )
 end, "CFC_ShipLister_MoveHUD" )
 
+cvars.AddChangeCallback( "cfc_chiplister_hud_size_frac", function( _, _, new )
+    if ignoringSizeConvar then return end
+    if not IsValid( listerPanel ) then return end
+
+    local size = getSizeFromConvar( tonumber( new ) )
+    listerPanel:SetSize( size, size, true )
+end, "CFC_ShipLister_ResizeHUD" )
+
 
 hook.Add( "AddToolMenuCategories", "CFC_ChipLister_AddToolMenuCategories", function()
     spawnmenu.AddToolCategory( "Options", "CFC", "#CFC" )
@@ -156,11 +171,17 @@ hook.Add( "PopulateToolMenu", "CFC_ChipLister_PopulateToolMenu", function()
         panel:CheckBox( "Enable E2/SF Lister", "cfc_chiplister_enabled" )
         panel:Button( "Toggle Chip Lister on HUD", "cfc_chiplister_toggle_hud" )
 
-        local btnReset = panel:Button( "Reset HUD Position" )
+        local btnResetPos = panel:Button( "Reset HUD Position" )
 
-        function btnReset:DoClick()
+        function btnResetPos:DoClick()
             PANEL_POS_FRAC_X:Revert()
             PANEL_POS_FRAC_Y:Revert()
+        end
+
+        local btnResetSize = panel:Button( "Reset HUD Size" )
+
+        function btnResetSize:DoClick()
+            PANEL_SIZE_FRAC:Revert()
         end
     end )
 end )

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -34,7 +34,11 @@ local function getPosFromConvar( fracX, fracY )
     if fracY < 0 then fracY = PANEL_DEFAULT_POS_FRAC_Y end
     fracY = math.Clamp( fracY, 0, 1 )
 
-    return fracX * ScrW(), fracY * ScrH()
+    local size = getSizeFromConvar()
+    local x = math.Clamp( fracX * ScrW(), 0, ScrW() - size )
+    local y = math.Clamp( fracY * ScrH(), 0, ScrH() - size )
+
+    return x, y
 end
 
 local function openListerPanel()

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -58,7 +58,7 @@ local function closeListerPanel()
 end
 
 local function toggleListerPanel()
-    if PANEL_PERSIST:GetBool() then
+    if IsValid( listerPanel ) and listerPanel:IsVisible() then
         closeListerPanel()
     else
         openListerPanel()

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -1,7 +1,7 @@
 local listerPanel
 local ignoringPosConvars = false
 
-local PANEL_MIN_SIZE_FRAC = 200 / 1080
+local PANEL_MIN_SIZE_FRAC = 300 / 1080
 local PANEL_DEFAULT_SIZE_FRAC = 400 / 1080
 
 local PANEL_PERSIST = CreateClientConVar( "cfc_chiplister_hud_persist", 0, true, true, "Causes the chiplister HUD element to persist across sessions." )
@@ -36,7 +36,7 @@ local function openListerPanel()
     listerPanel:SetPos( PANEL_POS_X:GetInt(), PANEL_POS_Y:GetInt() )
     listerPanel:SetSizable( true )
     listerPanel:SetScreenLock( true )
-    listerPanel:SetTitle( "E2/SF Lister" )
+    listerPanel:SetTitle( "E2/SF Lister    (Open chat for cursor)" )
 
     local imagePanel = vgui.Create( "DImage", listerPanel )
     imagePanel:SetPos( 10, 35 )

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -85,6 +85,13 @@ hook.Add( "PopulateToolMenu", "CFC_ChipLister_PopulateToolMenu", function()
     spawnmenu.AddToolMenuOption( "Options", "CFC", "cfc_chiplister", "#Chip Lister", "", "", function( panel )
         panel:CheckBox( "Enable E2/SF Lister", "cfc_chiplister_enabled" )
         panel:Button( "Toggle Chip Lister on HUD", "cfc_chiplister_toggle_hud" )
+
+        local btnReset = panel:Button( "Reset HUD Position" )
+
+        function btnReset:DoClick()
+            PANEL_POS_X:Revert()
+            PANEL_POS_Y:Revert()
+        end
     end )
 end )
 

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -1,4 +1,5 @@
 local listerPanel
+local ignoringPosConvars = false
 
 local PANEL_MIN_SIZE = 200
 
@@ -34,10 +35,16 @@ local function openListerPanel()
     end
 
     local _SetPos = listerPanel.SetPos
-    function listerPanel:SetPos( x, y )
+    function listerPanel:SetPos( x, y, noConvar )
         _SetPos( self, x, y )
-        LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_x " .. x )
-        LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_y " .. y )
+
+        if not noConvar then
+            local oldState = ignoringPosConvars
+            ignoringPosConvars = true
+            LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_x " .. x )
+            LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_y " .. y )
+            ignoringPosConvars = oldState
+        end
     end
 
     local _SetSize = listerPanel.SetSize
@@ -65,6 +72,15 @@ local function toggleListerPanel()
     end
 end
 
+local function setPosFromConvar( x, y )
+    if ignoringPosConvars then return end
+    if not IsValid( listerPanel ) then return end
+
+    x = x or PANEL_POS_X:GetInt()
+    y = y or PANEL_POS_Y:GetInt()
+    listerPanel:SetPos( x, y, true )
+end
+
 
 CreateMaterial( "cfc_chiplister_screen", "UnlitGeneric", {
     ["$basetexture"] = "cfc_chiplister_rt",
@@ -75,6 +91,15 @@ concommand.Add( "cfc_chiplister_open_hud", openListerPanel, nil, "Opens the Chip
 concommand.Add( "cfc_chiplister_close_hud", closeListerPanel, nil, "Closes the Chip Lister HUD element." )
 concommand.Add( "cfc_chiplister_toggle_hud", toggleListerPanel, nil, "Toggles the Chip Lister HUD element." )
 net.Receive( "CFC_ChipLister_ToggleHUD", toggleListerPanel )
+
+
+cvars.AddChangeCallback( "cfc_chiplister_hud_pos_x", function( _, _, new )
+    setPosFromConvar( tonumber( new ), nil )
+end, "CFC_ShipLister_MoveHUD" )
+
+cvars.AddChangeCallback( "cfc_chiplister_hud_pos_y", function( _, _, new )
+    setPosFromConvar( nil, tonumber( new ) )
+end, "CFC_ShipLister_MoveHUD" )
 
 
 hook.Add( "AddToolMenuCategories", "CFC_ChipLister_AddToolMenuCategories", function()

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -41,8 +41,8 @@ local function openListerPanel()
         if not noConvar then
             local oldState = ignoringPosConvars
             ignoringPosConvars = true
-            LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_x " .. x )
-            LocalPlayer():ConCommand( "cfc_chiplister_hud_pos_y " .. y )
+            PANEL_POS_X:SetInt( x )
+            PANEL_POS_Y:SetInt( y )
             ignoringPosConvars = oldState
         end
     end

--- a/lua/cfc_chip_lister/client/cl_hud.lua
+++ b/lua/cfc_chip_lister/client/cl_hud.lua
@@ -8,6 +8,8 @@ local PANEL_POS_X = CreateClientConVar( "cfc_chiplister_hud_pos_x", 50, true, fa
 local PANEL_POS_Y = CreateClientConVar( "cfc_chiplister_hud_pos_y", 25, true, false, "Y-Position of the chiplister HUD element." )
 local PANEL_SIZE = CreateClientConVar( "cfc_chiplister_hud_size", 275, true, false, "Size of the chiplister HUD element." )
 
+local LISTER_ENABLED = GetConVar( "cfc_chiplister_enabled" )
+
 
 local function openListerPanel()
     if IsValid( listerPanel ) then
@@ -28,6 +30,20 @@ local function openListerPanel()
     imagePanel:SetPos( 10, 35 )
     imagePanel:Dock( FILL )
     imagePanel:SetImage( "!cfc_chiplister_screen" )
+
+    local _imagePaint = imagePanel.Paint
+    function imagePanel:Paint( w, h )
+        if LISTER_ENABLED:GetBool() then
+            _imagePaint( self, w, h )
+            return
+        end
+
+        -- If lister is disabled, draw a custom message mentioning it.
+        -- Otherwise, the "Press E to toggle" text will show up from the RT, which only applies to placed listers.
+        surface.SetDrawColor( 0, 0, 0, 255 )
+        surface.DrawRect( 0, 0, w, h )
+        draw.SimpleText( "Chip Lister not enabled!", "CloseCaption_Bold", w / 2, h / 2, nil, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+    end
 
 
     function listerPanel:OnClose()


### PR DESCRIPTION
Various small tweaks to make the chip lister HUD better, and harder for people to be confused or get it stuck on their screen.

- Makes the HUD pos/size convars scale with screen resolution
  - Better default values too
  - Changing the convars now adjusts the panel immediately
  - Values get properly clamped now
- Adds pos/size reset buttons to the spawnmenu
- Changes the spawnmenu "open HUD" button to a toggle
- Adds text to the panel telling the player how to bring up their cursor
- When the HUD is enabled but the chip lister isn't, the panel now draws a message saying as much, instead of showing the "press E to turn on" text, which only applies to the placed entities.